### PR TITLE
Remove client_id

### DIFF
--- a/domainr.py
+++ b/domainr.py
@@ -3,7 +3,7 @@ import urllib2, json
 class Domainr:
 
 		def search(self, domain):
-		    base_url = "https://api.domainr.com/v1/search?client_id=python_connor_lib&q=" + domain
+		    base_url = "https://api.domainr.com/v1/search?client_id={your-mashape-key}&q=" + domain
 		    request = urllib2.Request(base_url)
 		    request.add_header('User-Agent', 'domainr.py/0.1')
 		    opener = urllib2.build_opener()
@@ -12,7 +12,7 @@ class Domainr:
 		    return response
 
 		def info(self, domain):
-		    base_url = "https://api.domainr.com/v1/info?client_id=python_connor_lib&q=" + domain
+		    base_url = "https://api.domainr.com/v1/info?client_id={your-mashape-key}&q=" + domain
 		    request = urllib2.Request(base_url)
 		    request.add_header('User-Agent', 'domainr.py/0.1')
 		    opener = urllib2.build_opener()


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).
